### PR TITLE
Add minimum python version requirement to the sync

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -2,6 +2,7 @@ import requests
 import os
 import json
 import hashlib
+import sys
 import threading
 import time
 from urllib.parse import urljoin
@@ -185,4 +186,6 @@ def skiller_whale_sync():
 
 
 if __name__ == "__main__":
+    if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 6):
+        raise Exception("Skiller Whale requires Python 3.6 or Higher")
     skiller_whale_sync()


### PR DESCRIPTION
This will raise an exception if Python 3.5 or earlier is running.
Although this is quite a drastic exception, learners could comment out
this line of the sync if they urgently need to run an earlier version.